### PR TITLE
Add config to toggle block outline rendering

### DIFF
--- a/src/main/java/com/feed_the_beast/mods/ftbultimine/FTBUltimineConfig.java
+++ b/src/main/java/com/feed_the_beast/mods/ftbultimine/FTBUltimineConfig.java
@@ -23,6 +23,7 @@ public class FTBUltimineConfig
 	public static boolean mergeStone;
 	public static final HashSet<ResourceLocation> toolBlacklist = new HashSet<>();
 	public static int renderTextManually;
+	public static boolean renderOutline;
 
 	private static Pair<CommonConfig, ForgeConfigSpec> server;
 
@@ -55,6 +56,7 @@ public class FTBUltimineConfig
 			}
 
 			renderTextManually = c.renderTextManually.get();
+			renderOutline = c.renderOutline.get();
 		}
 	}
 
@@ -65,6 +67,7 @@ public class FTBUltimineConfig
 		private final ForgeConfigSpec.BooleanValue mergeStone;
 		private final ForgeConfigSpec.ConfigValue<List<? extends String>> toolBlacklist;
 		private final ForgeConfigSpec.IntValue renderTextManually;
+		private final ForgeConfigSpec.BooleanValue renderOutline;
 
 		private CommonConfig(ForgeConfigSpec.Builder builder)
 		{
@@ -92,6 +95,11 @@ public class FTBUltimineConfig
 					.comment("Required for some modpacks")
 					.translation("ftbultimine.render_text_manually")
 					.defineInRange("render_text_manually", -1, -1, 8);
+
+			renderOutline = builder
+					.comment("Render the white outline around blocks to be mined")
+					.translation("ftbultimine.render_outline")
+					.define("render_outline", true);
 		}
 	}
 }

--- a/src/main/java/com/feed_the_beast/mods/ftbultimine/net/SendShapePacket.java
+++ b/src/main/java/com/feed_the_beast/mods/ftbultimine/net/SendShapePacket.java
@@ -53,7 +53,10 @@ public class SendShapePacket
 	{
 		context.get().enqueueWork(() -> {
 			current = shape;
-			FTBUltimine.instance.proxy.setShape(blocks);
+			
+			if (FTBUltimineConfig.renderOutline) {
+				FTBUltimine.instance.proxy.setShape(blocks);
+			}
 		});
 
 		context.get().setPacketHandled(true);


### PR DESCRIPTION
I've noticed setting a `max_block` limit in the config higher than the default 64 started to increase tick times substantially. In profiles I ran it was showing `FTBUltimineClient.updateEdges()` as the culprit when having to calculate where to draw everything. The higher tick time is much more noticeable on plants than with normal blocks.

Spark profile for reference: https://spark.lucko.me/#epJ6sscCtx

I'm nowhere near up to speed with how Minecraft Forge mods work to be able to help with any drawing optimization, or if this check for the config is in the appropriate spot. I did test on a local build and it worked for me. Setting `renderOutline` to false in my config prevented the outline showing in the client and still mined everything as it should, even with a 512 `max_blocks` limit, without any tick lag.