### PR TITLE
Add configurable key bindings to change shape

### DIFF
--- a/src/main/resources/assets/ftbultimine/lang/en_us.json
+++ b/src/main/resources/assets/ftbultimine/lang/en_us.json
@@ -1,5 +1,8 @@
 {
-	"key.ftbultimine": "FTB Ultimine",
+	"key.categories.ftbultimine": "FTB Ultimine",
+	"key.ftbultimine.activate": "Activate FTB Ultimine",
+	"key.ftbultimine.previous_shape": "Previous Shape",
+	"key.ftbultimine.next_shape": "Next Shape",
 	"ftbultimine.active": "FTB Ultimine is active",
 	"ftbultimine.change_shape": "Hold Shift + Scroll Mouse to change shape",
 	"ftbultimine.shape.shapeless": "Shapeless",


### PR DESCRIPTION
The goal was to add a way to work around the compatibility issues on Mac when using Shift + Scroll (#29), while also making the mod a bit more configurable.

I didn't touch the scroll wheel logic, but since I'm on Mac I can't test it. I'd appreciate if someone could actually validate that I didn't break the existing behavior.

I've tested both in single player and a server, although I didn't have to update the .jar in the server (since I only changed client code).