### PR TITLE
Allow wildcard merge tags

### DIFF
--- a/common/src/main/java/dev/ftb/mods/ftbultimine/config/FTBUltimineServerConfig.java
+++ b/common/src/main/java/dev/ftb/mods/ftbultimine/config/FTBUltimineServerConfig.java
@@ -9,13 +9,14 @@ import me.shedaniel.architectury.hooks.LevelResourceHooks;
 import me.shedaniel.architectury.hooks.TagHooks;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.MinecraftServer;
+import net.minecraft.tags.BlockTags;
 import net.minecraft.tags.Tag;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.storage.LevelResource;
 
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashSet;
+import java.util.Arrays;
 import java.util.List;
 
 /**
@@ -37,8 +38,8 @@ public interface FTBUltimineServerConfig {
 			.range(10000)
 			.comment("Hunger multiplied for each block mined with ultimine");
 
-	BlockTagsConfig MERGE_TAGS = new BlockTagsConfig(CONFIG, "merge_tags", Collections.singletonList("minecraft:base_stone_overworld"),
-			"These tags will be considered the same block when checking for blocks to Ultimine");
+	BlockTagsConfig MERGE_TAGS = new BlockTagsConfig(CONFIG, "merge_tags", Arrays.asList("minecraft:base_stone_overworld", "forge:ores/*"),
+    "These tags will be considered the same block when checking for blocks to Ultimine");
 
 	static void load(MinecraftServer server) {
 		CONFIG.load(server.getWorldPath(CONFIG_FILE_PATH));
@@ -66,7 +67,17 @@ public interface FTBUltimineServerConfig {
 		public Collection<Tag<Block>> getTags() {
 			if (tags == null) {
 				tags = new HashSet<>();
-				value.get().forEach(s -> tags.add(TagHooks.getBlockOptional(new ResourceLocation(s))));
+				value.get().forEach(s -> {
+                    if(s.endsWith("*")){
+                        BlockTags.getAllTags().getAllTags().forEach(((resourceLocation, blockTag) -> {
+                            if (resourceLocation.toString().startsWith(s.substring(0, s.length() - 1))) {
+                                tags.add(TagHooks.getBlockOptional(resourceLocation));
+                            }
+                        }));
+                    } else {
+                        tags.add(TagHooks.getBlockOptional(new ResourceLocation(s)));
+                    }
+                });
 			}
 			return tags;
 		}


### PR DESCRIPTION
This pull request has been written with enigmatica 6 in mind, in it's worldgen ore veins can generate inside different types of stone, which by default do not get taken into account when trying to ultimine them.

The obvious solution would be to add a `forge:ores/iron` etc for each type of ore in the pack, but that would require constant babysitting for when (new) ores get added or removed.

That is why this pull request tries to introduce a wildcard mechanism: if the tag **starts** with whatever is in front of the asterix it will artificially get added to the merge_tags, it does **not** cause different types of ores to clump together.

Here is some log output from when i was building it to visualize the concept:

```
minecraft:base_stone_overworld (gets handled by the existing code)
forge:ores/* (causes a lookup of all tags that start with it)
forge:ores/quartz (this & below are all the tags present in "vanilla")
forge:ores/netherite_scrap
forge:ores/redstone
forge:ores/diamond
forge:ores/gold
forge:ores/lapis
forge:ores/iron
forge:ores/coal
forge:ores/emerald
```

when tested in enigmatica 6 version 0.5.16 you will be getting this result now:
![2021-10-21_11 06 48](https://user-images.githubusercontent.com/3179271/138248901-d4e172be-2978-43ef-bcdc-cdefbb8ec8f5.png)

some things to consider before merging:

- i'm not sure if `Arrays.asList` is the one you would have used, but singleton obviously had to go (defaultconfig for servers still doesn't copy as of late so i figured it would be most practical to add one more default merge tag)

- the config currently generates like this instead of all on the same line: (and without a comma)
```
	merge_tags: [
		"minecraft:base_stone_overworld"
		"forge:ores/*"
	]
```

- not sure if i could have used the `blockTag` instead of `TagHooks.getBlockOptional`, but i don't understand what it does enough, so i used the safe option and reused the existing method and only swapping out the resource location

- the `BlockTags.getAllTags().getAllTags().forEach` & `resourceLocation.toString().startsWith(s.substring(0, s.length() - 1))` look a bit messy, but at least they work :)

- used named imports even though my code editor suggested .* since that seemed to be the theme here (^-^) 
