### PR TITLE
Added Mining Gadgets MK II and MK III to strict excluded tools tags 

### DIFF
--- a/common/src/main/resources/data/ftbultimine/tags/items/excluded_tools/strict.json
+++ b/common/src/main/resources/data/ftbultimine/tags/items/excluded_tools/strict.json
@@ -6,6 +6,14 @@
 			"required": false
 		},
 		{
+			"id": "mininggadgets:mininggadget_simple",
+			"required": false
+		},
+		{
+			"id": "mininggadgets:mininggadget_fancy",
+			"required": false
+		},
+		{
 			"id": "ars_nouveau:wand",
 			"required": false
 		},


### PR DESCRIPTION
These are new-ish versions of the standard Mining Gadget