### PR TITLE
fix: ftb library slug for forge/neoforge [ciskip]

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -146,7 +146,7 @@ publishMods {
 		from(curseForgeOptions, neoForgeOptions)
 		projectId = curseforge_id_forge
 		requires {slug = "architectury-api" }
-		requires {slug = 'ftb-library-neoforge' }
-		optional {slug = 'ftb-ranks-neoforge' }
+		requires {slug = 'ftb-library-forge' }
+		optional {slug = 'ftb-ranks-forge' }
 	}
 }


### PR DESCRIPTION
One more publishing fix...