### PR TITLE
Cooldown feature (backport) into 1.19.2

### DIFF
--- a/common/src/main/java/dev/ftb/mods/ftbultimine/CooldownTracker.java
+++ b/common/src/main/java/dev/ftb/mods/ftbultimine/CooldownTracker.java
@@ -1,0 +1,68 @@
+package dev.ftb.mods.ftbultimine;
+
+import dev.ftb.mods.ftbultimine.config.FTBUltimineServerConfig;
+import dev.ftb.mods.ftbultimine.net.SyncUltimineTimePacket;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.util.Mth;
+import net.minecraft.world.entity.player.Player;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+public class CooldownTracker {
+    private static final CooldownTracker clientInstance = new CooldownTracker();
+    private static final CooldownTracker serverInstance = new CooldownTracker();
+
+    private final Map<UUID,Long> lastUltimineTime = new HashMap<>();
+
+    // client can't just look at the server config (even though it's sync'd) since we could be using Ranks...
+    // so this get sync'd when the server config changes, or when we get a Ranks event indicating a change
+    private static long ultimineCooldownClient;
+
+    public static long getLastUltimineTime(Player player) {
+        CooldownTracker instance = player.level.isClientSide ? clientInstance : serverInstance;
+        return instance.lastUltimineTime.getOrDefault(player.getUUID(), 0L);
+    }
+
+    public static void setLastUltimineTime(Player player, long when) {
+        CooldownTracker instance = player.level.isClientSide ? clientInstance : serverInstance;
+        instance.lastUltimineTime.put(player.getUUID(), when);
+        if (player instanceof ServerPlayer sp) {
+            new SyncUltimineTimePacket(when, SyncUltimineTimePacket.TimeType.LAST_USED).sendTo(sp);
+        }
+    }
+
+    /**
+     * Get the remaining cooldown time for the player as a proportion of total time
+     * @param player the player to check
+     * @return a value in the range 0f -> 1f
+     */
+    public static float getCooldownRemaining(Player player) {
+        long coolDown = getUltimineCooldown(player);
+        if (coolDown == 0L) {
+            return 1f;
+        }
+        long tickDelta = (System.currentTimeMillis() - getLastUltimineTime(player)) / 50;  // ms -> ticks
+        return Mth.clamp((float)tickDelta / coolDown, 0f, 1f);
+    }
+
+    public static boolean isOnCooldown(Player player) {
+        long coolDown = getUltimineCooldown(player);
+        if (coolDown == 0L) {
+            return false;
+        }
+        long coolDownMs = coolDown * 50;  // ticks -> ms
+        return coolDownMs > 0L && System.currentTimeMillis() - getLastUltimineTime(player) < coolDownMs;
+    }
+
+    private static long getUltimineCooldown(Player player) {
+        return player instanceof ServerPlayer sp ?
+                FTBUltimineServerConfig.getUltimineCooldown(sp) :
+                ultimineCooldownClient;
+    }
+
+    public static void setClientCooldownTime(long cooldown) {
+        ultimineCooldownClient = cooldown;
+    }
+}

--- a/common/src/main/java/dev/ftb/mods/ftbultimine/client/UltimineRenderTypes.java
+++ b/common/src/main/java/dev/ftb/mods/ftbultimine/client/UltimineRenderTypes.java
@@ -11,7 +11,7 @@ import java.util.OptionalDouble;
  * @author LatvianModder
  */
 public class UltimineRenderTypes extends RenderType {
-	public static final RenderType LINES_NORMAL = RenderType.create("ultimine_lines_normal", DefaultVertexFormat.POSITION_COLOR, VertexFormat.Mode.DEBUG_LINES, 256, false, false, RenderType.CompositeState.builder()
+	public static final RenderType LINES_NORMAL = RenderType.create("ultimine_lines_normal", DefaultVertexFormat.POSITION_COLOR, VertexFormat.Mode.DEBUG_LINES, 256, false, false, CompositeState.builder()
 			.setShaderState(new ShaderStateShard(GameRenderer::getPositionColorShader))
 			.setLineState(new LineStateShard(OptionalDouble.empty()))
 			.setLayeringState(NO_LAYERING)
@@ -20,7 +20,7 @@ public class UltimineRenderTypes extends RenderType {
 			.setCullState(CULL)
 			.createCompositeState(false));
 
-	public static final RenderType LINES_TRANSPARENT = RenderType.create("ultimine_lines_transparent", DefaultVertexFormat.POSITION_COLOR, VertexFormat.Mode.DEBUG_LINES, 256, false, false, RenderType.CompositeState.builder()
+	public static final RenderType LINES_TRANSPARENT = RenderType.create("ultimine_lines_transparent", DefaultVertexFormat.POSITION_COLOR, VertexFormat.Mode.DEBUG_LINES, 256, false, false, CompositeState.builder()
 			.setShaderState(new ShaderStateShard(GameRenderer::getPositionColorShader))
 			.setLineState(new LineStateShard(OptionalDouble.empty()))
 			.setLayeringState(NO_LAYERING)

--- a/common/src/main/java/dev/ftb/mods/ftbultimine/config/FTBUltimineServerConfig.java
+++ b/common/src/main/java/dev/ftb/mods/ftbultimine/config/FTBUltimineServerConfig.java
@@ -75,6 +75,9 @@ public interface FTBUltimineServerConfig {
 	BooleanValue RIGHT_CLICK_HARVESTING = CONFIG.getBoolean("right_click_harvesting", true)
 			.comment("Right-click crops with the Ultimine key held to harvest multiple crop blocks");
 
+	LongValue ULTIMINE_COOLDOWN = CONFIG.getLong("ultimine_cooldown", 0L, 0L, Long.MAX_VALUE)
+			.comment("Cooldown in ticks between successive uses of the ultimine feature.");
+
 //	BooleanValue USE_TRINKET = CONFIG.getBoolean("use_trinket", false)
 //			.comment("(This only works if the mod 'Lost Trinkets' is installed!)",
 //					"Adds a custom 'Ultiminer' trinket players will need to activate to be able to use Ultimine.",
@@ -131,6 +134,10 @@ public interface FTBUltimineServerConfig {
 
 	static int getMaxBlocks(ServerPlayer player) {
 		return ranksMod ? FTBRanksIntegration.getMaxBlocks(player) : MAX_BLOCKS.get();
+	}
+
+	static long getUltimineCooldown(ServerPlayer player) {
+		return ranksMod ? FTBRanksIntegration.getUltimineCooldown(player) : ULTIMINE_COOLDOWN.get();
 	}
 
 	class BlockTagsConfig {

--- a/common/src/main/java/dev/ftb/mods/ftbultimine/integration/FTBRanksIntegration.java
+++ b/common/src/main/java/dev/ftb/mods/ftbultimine/integration/FTBRanksIntegration.java
@@ -1,14 +1,46 @@
 package dev.ftb.mods.ftbultimine.integration;
 
 import dev.ftb.mods.ftbranks.api.FTBRanksAPI;
+import dev.ftb.mods.ftbranks.api.event.RankEvent;
+import dev.ftb.mods.ftbultimine.FTBUltimine;
 import dev.ftb.mods.ftbultimine.config.FTBUltimineServerConfig;
+import dev.ftb.mods.ftbultimine.net.SyncUltimineTimePacket;
 import net.minecraft.server.level.ServerPlayer;
 
 public class FTBRanksIntegration {
     private static final String MAX_BLOCKS_PERM = "ftbultimine.max_blocks";
+    private static final String COOLDOWN_PERM = "ftbultimine.ultimine_cooldown";
+
+    public static void init() {
+        RankEvent.ADD_PLAYER.register(FTBRanksIntegration::updatePlayer);
+        RankEvent.REMOVE_PLAYER.register(FTBRanksIntegration::updatePlayer);
+        RankEvent.PERMISSION_CHANGED.register(FTBRanksIntegration::updateAllPlayers);
+        RankEvent.RELOADED.register(FTBRanksIntegration::updateAllPlayers);
+        RankEvent.CONDITION_CHANGED.register(FTBRanksIntegration::updateAllPlayers);
+
+        FTBUltimine.LOGGER.info("FTB Ranks detected, listening for ranks events");
+    }
 
     public static int getMaxBlocks(ServerPlayer player) {
         return FTBRanksAPI.getPermissionValue(player, MAX_BLOCKS_PERM).asInteger()
                 .orElse(FTBUltimineServerConfig.MAX_BLOCKS.get());
+    }
+
+    private static void updatePlayer(RankEvent.Player event) {
+        ServerPlayer sp = event.getManager().getServer().getPlayerList().getPlayer(event.getPlayer().getId());
+        if (sp != null) {
+            new SyncUltimineTimePacket(FTBUltimineServerConfig.getUltimineCooldown(sp), SyncUltimineTimePacket.TimeType.COOLDOWN).sendTo(sp);
+        }
+    }
+
+    private static void updateAllPlayers(RankEvent event) {
+        event.getManager().getServer().getPlayerList().getPlayers().forEach(sp -> {
+            new SyncUltimineTimePacket(FTBUltimineServerConfig.getUltimineCooldown(sp), SyncUltimineTimePacket.TimeType.COOLDOWN).sendTo(sp);
+        });
+    }
+
+    public static long getUltimineCooldown(ServerPlayer player) {
+        return FTBRanksAPI.getPermissionValue(player, COOLDOWN_PERM).asLong()
+                .orElse(FTBUltimineServerConfig.ULTIMINE_COOLDOWN.get());
     }
 }

--- a/common/src/main/java/dev/ftb/mods/ftbultimine/net/FTBUltimineNet.java
+++ b/common/src/main/java/dev/ftb/mods/ftbultimine/net/FTBUltimineNet.java
@@ -16,6 +16,7 @@ public interface FTBUltimineNet {
 	MessageType SYNC_CONFIG_FROM_SERVER = NET.registerS2C("sync_config_from_server", SyncConfigFromServerPacket::new);
 	MessageType SYNC_CONFIG_TO_SERVER = NET.registerC2S("sync_config_to_server", SyncConfigToServerPacket::new);
 	MessageType EDIT_CONFIG = NET.registerS2C("edit_config", EditConfigPacket::new);
+	MessageType SYNC_ULTIMINE_TIME = NET.registerS2C("sync_ultimine_time", SyncUltimineTimePacket::new);
 
 	static void init() {
 	}

--- a/common/src/main/java/dev/ftb/mods/ftbultimine/net/SyncConfigToServerPacket.java
+++ b/common/src/main/java/dev/ftb/mods/ftbultimine/net/SyncConfigToServerPacket.java
@@ -51,7 +51,7 @@ public class SyncConfigToServerPacket extends BaseC2SMessage {
                 if (!sp.getUUID().equals(player.getUUID())) {
                     new SyncConfigFromServerPacket(config).sendTo(player);
                 }
-                new SyncUltimineTimePacket(FTBUltimineServerConfig.getUltimineCooldown(player), SyncUltimineTimePacket.TimeType.COOLDOWN.COOLDOWN).sendTo(player);
+                new SyncUltimineTimePacket(FTBUltimineServerConfig.getUltimineCooldown(player), SyncUltimineTimePacket.TimeType.COOLDOWN).sendTo(player);
             }
         }
     }

--- a/common/src/main/java/dev/ftb/mods/ftbultimine/net/SyncConfigToServerPacket.java
+++ b/common/src/main/java/dev/ftb/mods/ftbultimine/net/SyncConfigToServerPacket.java
@@ -51,6 +51,7 @@ public class SyncConfigToServerPacket extends BaseC2SMessage {
                 if (!sp.getUUID().equals(player.getUUID())) {
                     new SyncConfigFromServerPacket(config).sendTo(player);
                 }
+                new SyncUltimineTimePacket(FTBUltimineServerConfig.getUltimineCooldown(player), SyncUltimineTimePacket.TimeType.COOLDOWN.COOLDOWN).sendTo(player);
             }
         }
     }

--- a/common/src/main/java/dev/ftb/mods/ftbultimine/net/SyncUltimineTimePacket.java
+++ b/common/src/main/java/dev/ftb/mods/ftbultimine/net/SyncUltimineTimePacket.java
@@ -1,0 +1,48 @@
+package dev.ftb.mods.ftbultimine.net;
+
+import dev.architectury.networking.NetworkManager;
+import dev.architectury.networking.simple.BaseS2CMessage;
+import dev.architectury.networking.simple.MessageType;
+import dev.ftb.mods.ftbultimine.CooldownTracker;
+import dev.ftb.mods.ftbultimine.client.FTBUltimineClient;
+import net.minecraft.network.FriendlyByteBuf;
+
+public class SyncUltimineTimePacket extends BaseS2CMessage {
+
+    private final long when;
+    private final TimeType timetype;
+
+    public SyncUltimineTimePacket(FriendlyByteBuf buf) {
+        this.when = buf.readLong();
+        this.timetype = buf.readEnum(TimeType.class);
+    }
+
+    public SyncUltimineTimePacket(long when, TimeType timetype) {
+        this.when = when;
+        this.timetype = timetype;
+    }
+
+    @Override
+    public MessageType getType() {
+        return FTBUltimineNet.SYNC_ULTIMINE_TIME;
+    }
+
+    @Override
+    public void write(FriendlyByteBuf buf) {
+        buf.writeLong(when);
+        buf.writeEnum(timetype);
+    }
+
+    @Override
+    public void handle(NetworkManager.PacketContext context) {
+        switch (timetype) {
+            case LAST_USED -> CooldownTracker.setLastUltimineTime(FTBUltimineClient.getClientPlayer(), when);
+            case COOLDOWN -> CooldownTracker.setClientCooldownTime(when);
+        }
+    }
+
+    public enum TimeType {
+        COOLDOWN,
+        LAST_USED
+    }
+}

--- a/common/src/main/java/dev/ftb/mods/ftbultimine/utils/NonnullByDefault.java
+++ b/common/src/main/java/dev/ftb/mods/ftbultimine/utils/NonnullByDefault.java
@@ -1,0 +1,1 @@
+package dev.ftb.mods.ftbultimine.utils;

--- a/common/src/main/resources/assets/ftbultimine/lang/en_us.json
+++ b/common/src/main/resources/assets/ftbultimine/lang/en_us.json
@@ -40,5 +40,7 @@
 	"ftbultimine.server_settings.right_click_axe": "Axe: Right-Click multiple blocks",
 	"ftbultimine.server_settings.right_click_hoe": "Hoe: Right-Click multiple blocks",
 	"ftbultimine.server_settings.right_click_shovel": "Shovel: Right-Click multiple blocks",
-	"ftbultimine.server_settings.right_click_harvesting": "Allow Ultimine harvesting of crops"
+	"ftbultimine.server_settings.right_click_harvesting": "Allow Ultimine harvesting of crops",
+	"ftbultimine.server_settings.ultimine_cooldown": "Ultimine cooldown (ticks)",
+	"ftbultimine.server_settings.ultimine_cooldown.tooltip": "Time in ticks required between successive uses of the Ultimine function\nIf FTB Ranks is installed, the 'ftbultimine.ultimine_cooldown' node takes priority, if present"
 }

--- a/common/src/main/resources/assets/ftbultimine/lang/en_us.json
+++ b/common/src/main/resources/assets/ftbultimine/lang/en_us.json
@@ -6,6 +6,7 @@
 	"ftbultimine.info.not_active": "not active",
 	"ftbultimine.info.blocks": "Mining %d blocks",
 	"ftbultimine.info.partial_render": "%d rendered",
+	"ftbultimine.info.cooldown": "on cooldown",
 	"ftbultimine.change_shape": "Hold Shift + (Scroll Mouse or Arrow up/down) to change shape",
 	"ftbultimine.shape.shapeless": "Shapeless",
 	"ftbultimine.shape.small_tunnel": "Small Tunnel",

--- a/common/src/main/resources/ftbultimine-common.mixins.json
+++ b/common/src/main/resources/ftbultimine-common.mixins.json
@@ -11,5 +11,6 @@
   "injectors": {
     "defaultRequire": 1
   },
-  "minVersion": "0.8"
+  "minVersion": "0.8",
+  "refmap": "ftb-ultimine-common-refmap.json"
 }

--- a/common/src/main/resources/ftbultimine-common.mixins.json
+++ b/common/src/main/resources/ftbultimine-common.mixins.json
@@ -12,5 +12,4 @@
     "defaultRequire": 1
   },
   "minVersion": "0.8",
-  "refmap": "ftb-ultimine-common-refmap.json"
 }

--- a/common/src/main/resources/ftbultimine-common.mixins.json
+++ b/common/src/main/resources/ftbultimine-common.mixins.json
@@ -11,5 +11,5 @@
   "injectors": {
     "defaultRequire": 1
   },
-  "minVersion": "0.8",
+  "minVersion": "0.8"
 }


### PR DESCRIPTION
Hey,
I've backported the ultimine cooldown feature from the later versions back to 1.19.2...

This was originally a private port used on our public fabric server, however CurseForge won't allow us to publish our modpack with the private port due to your licensing / no permission

