### PR TITLE
Fix multi right-click with custom items on Forge

### DIFF
--- a/common/src/main/java/dev/ftb/mods/ftbultimine/FTBUltimine.java
+++ b/common/src/main/java/dev/ftb/mods/ftbultimine/FTBUltimine.java
@@ -22,6 +22,7 @@ import dev.ftb.mods.ftbultimine.net.SyncConfigFromServerPacket;
 import dev.ftb.mods.ftbultimine.net.SyncUltimineTimePacket;
 import dev.ftb.mods.ftbultimine.net.SyncUltimineTimePacket.TimeType;
 import dev.ftb.mods.ftbultimine.shape.*;
+import dev.ftb.mods.ftbultimine.utils.PlatformMethods;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.core.registries.Registries;
@@ -305,16 +306,7 @@ public class FTBUltimine {
 			return EventResult.pass();
 		}
 
-		int didWork = 0;
-		if (FTBUltimineServerConfig.RIGHT_CLICK_HARVESTING.get() && shapeContext.matcher() == BlockMatcher.CROP_LIKE) {
-			didWork = RightClickHandlers.cropHarvesting(serverPlayer, hand, clickPos, face, data);
-		} else if (FTBUltimineServerConfig.RIGHT_CLICK_HOE.get() && serverPlayer.getItemInHand(hand).getItem() instanceof HoeItem) {
-			didWork = RightClickHandlers.farmlandConversion(serverPlayer, hand, clickPos, data);
-		} else if (FTBUltimineServerConfig.RIGHT_CLICK_AXE.get() && serverPlayer.getItemInHand(hand).getItem() instanceof AxeItem) {
-			didWork = RightClickHandlers.axeStripping(serverPlayer, hand, clickPos, data);
-		} else if (FTBUltimineServerConfig.RIGHT_CLICK_SHOVEL.get() && serverPlayer.getItemInHand(hand).getItem() instanceof ShovelItem) {
-			didWork = RightClickHandlers.shovelFlattening(serverPlayer, hand, clickPos, data);
-		}
+		int didWork = PlatformMethods.blockRightClick(shapeContext, serverPlayer, hand, clickPos, face, data);
 
 		if (didWork > 0) {
 			player.swing(hand);

--- a/common/src/main/java/dev/ftb/mods/ftbultimine/RightClickHandlers.java
+++ b/common/src/main/java/dev/ftb/mods/ftbultimine/RightClickHandlers.java
@@ -28,7 +28,7 @@ import java.util.Optional;
 import java.util.Set;
 
 public class RightClickHandlers {
-    static int axeStripping(ServerPlayer player, InteractionHand hand, BlockPos clickPos, FTBUltiminePlayerData data) {
+    public static int axeStripping(ServerPlayer player, InteractionHand hand, BlockPos clickPos, FTBUltiminePlayerData data) {
         Set<SoundEvent> sounds = new HashSet<>();
         BrokenItemHandler brokenItemHandler = new BrokenItemHandler();
         Level level = player.level();
@@ -71,7 +71,7 @@ public class RightClickHandlers {
         return sounds.size();
     }
 
-    static int shovelFlattening(ServerPlayer player, InteractionHand hand, BlockPos clickPos, FTBUltiminePlayerData data) {
+    public static int shovelFlattening(ServerPlayer player, InteractionHand hand, BlockPos clickPos, FTBUltiminePlayerData data) {
         int didWork = 0;
         BrokenItemHandler brokenItemHandler = new BrokenItemHandler();
 
@@ -106,7 +106,7 @@ public class RightClickHandlers {
         return didWork;
     }
 
-    static int farmlandConversion(ServerPlayer player, InteractionHand hand, BlockPos clickPos, FTBUltiminePlayerData data) {
+    public static int farmlandConversion(ServerPlayer player, InteractionHand hand, BlockPos clickPos, FTBUltiminePlayerData data) {
         int clicked = 0;
         BrokenItemHandler brokenItemHandler = new BrokenItemHandler();
 
@@ -137,7 +137,7 @@ public class RightClickHandlers {
         return clicked;
     }
 
-    static int cropHarvesting(ServerPlayer player, InteractionHand hand, BlockPos clickPos, Direction face, FTBUltiminePlayerData data) {
+    public static int cropHarvesting(ServerPlayer player, InteractionHand hand, BlockPos clickPos, Direction face, FTBUltiminePlayerData data) {
         MutableInt clicked = new MutableInt();
         ItemCollection itemCollection = new ItemCollection();
 

--- a/common/src/main/java/dev/ftb/mods/ftbultimine/utils/PlatformMethods.java
+++ b/common/src/main/java/dev/ftb/mods/ftbultimine/utils/PlatformMethods.java
@@ -1,11 +1,21 @@
 package dev.ftb.mods.ftbultimine.utils;
 
 import dev.architectury.injectables.annotations.ExpectPlatform;
+import dev.ftb.mods.ftbultimine.FTBUltiminePlayerData;
+import dev.ftb.mods.ftbultimine.shape.ShapeContext;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
 import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.InteractionHand;
 
 public class PlatformMethods {
 	@ExpectPlatform
 	public static double reach(ServerPlayer player) {
+		throw new AssertionError();
+	}
+
+	@ExpectPlatform
+	public static int blockRightClick(ShapeContext shapeContext, ServerPlayer player, InteractionHand hand, BlockPos clickPos, Direction face, FTBUltiminePlayerData data) {
 		throw new AssertionError();
 	}
 }

--- a/fabric/src/main/java/dev/ftb/mods/ftbultimine/utils/fabric/PlatformMethodsImpl.java
+++ b/fabric/src/main/java/dev/ftb/mods/ftbultimine/utils/fabric/PlatformMethodsImpl.java
@@ -1,10 +1,42 @@
 package dev.ftb.mods.ftbultimine.utils.fabric;
 
 import com.jamieswhiteshirt.reachentityattributes.ReachEntityAttributes;
+import dev.ftb.mods.ftbultimine.FTBUltiminePlayerData;
+import dev.ftb.mods.ftbultimine.RightClickHandlers;
+import dev.ftb.mods.ftbultimine.config.FTBUltimineServerConfig;
+import dev.ftb.mods.ftbultimine.shape.BlockMatcher;
+import dev.ftb.mods.ftbultimine.shape.ShapeContext;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
 import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.InteractionHand;
+import net.minecraft.world.item.AxeItem;
+import net.minecraft.world.item.HoeItem;
+import net.minecraft.world.item.ShovelItem;
 
 public class PlatformMethodsImpl {
 	public static double reach(ServerPlayer player) {
 		return ReachEntityAttributes.getReachDistance(player, player.isCreative() ? 5.0 : 4.5);
+	}
+
+	public static int blockRightClick(ShapeContext shapeContext, ServerPlayer serverPlayer, InteractionHand hand, BlockPos clickPos, Direction face, FTBUltiminePlayerData data) {
+		int didWork = 0;
+		if (FTBUltimineServerConfig.RIGHT_CLICK_HARVESTING.get() && shapeContext.matcher() == BlockMatcher.CROP_LIKE) {
+			return RightClickHandlers.cropHarvesting(serverPlayer, hand, clickPos, face, data);
+		}
+
+		if (FTBUltimineServerConfig.RIGHT_CLICK_HOE.get() && serverPlayer.getItemInHand(hand).getItem() instanceof HoeItem) {
+			return RightClickHandlers.farmlandConversion(serverPlayer, hand, clickPos, data);
+		}
+
+		if (FTBUltimineServerConfig.RIGHT_CLICK_AXE.get() && serverPlayer.getItemInHand(hand).getItem() instanceof AxeItem) {
+			return RightClickHandlers.axeStripping(serverPlayer, hand, clickPos, data);
+		}
+
+		if (FTBUltimineServerConfig.RIGHT_CLICK_SHOVEL.get() && serverPlayer.getItemInHand(hand).getItem() instanceof ShovelItem) {
+			return RightClickHandlers.shovelFlattening(serverPlayer, hand, clickPos, data);
+		}
+
+		return didWork;
 	}
 }

--- a/forge/src/main/java/dev/ftb/mods/ftbultimine/utils/forge/PlatformMethodsImpl.java
+++ b/forge/src/main/java/dev/ftb/mods/ftbultimine/utils/forge/PlatformMethodsImpl.java
@@ -1,10 +1,43 @@
 package dev.ftb.mods.ftbultimine.utils.forge;
 
+import dev.ftb.mods.ftbultimine.FTBUltiminePlayerData;
+import dev.ftb.mods.ftbultimine.RightClickHandlers;
+import dev.ftb.mods.ftbultimine.config.FTBUltimineServerConfig;
+import dev.ftb.mods.ftbultimine.shape.BlockMatcher;
+import dev.ftb.mods.ftbultimine.shape.ShapeContext;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
 import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.InteractionHand;
+import net.minecraft.world.item.AxeItem;
+import net.minecraft.world.item.HoeItem;
+import net.minecraft.world.item.ShovelItem;
 import net.minecraftforge.common.ForgeMod;
+import net.minecraftforge.common.ToolActions;
 
 public class PlatformMethodsImpl {
 	public static double reach(ServerPlayer player) {
 		return player.getAttributeValue(ForgeMod.BLOCK_REACH.get());
+	}
+
+	public static int blockRightClick(ShapeContext shapeContext, ServerPlayer serverPlayer, InteractionHand hand, BlockPos clickPos, Direction face, FTBUltiminePlayerData data) {
+		int didWork = 0;
+		if (FTBUltimineServerConfig.RIGHT_CLICK_HARVESTING.get() && shapeContext.matcher() == BlockMatcher.CROP_LIKE) {
+			return RightClickHandlers.cropHarvesting(serverPlayer, hand, clickPos, face, data);
+		}
+
+		if (FTBUltimineServerConfig.RIGHT_CLICK_HOE.get() && serverPlayer.getItemInHand(hand).canPerformAction(ToolActions.HOE_TILL)) {
+			return RightClickHandlers.farmlandConversion(serverPlayer, hand, clickPos, data);
+		}
+
+		if (FTBUltimineServerConfig.RIGHT_CLICK_AXE.get() && serverPlayer.getItemInHand(hand).canPerformAction(ToolActions.AXE_STRIP)) {
+			return RightClickHandlers.axeStripping(serverPlayer, hand, clickPos, data);
+		}
+
+		if (FTBUltimineServerConfig.RIGHT_CLICK_SHOVEL.get() && serverPlayer.getItemInHand(hand).canPerformAction(ToolActions.SHOVEL_FLATTEN)) {
+			return RightClickHandlers.shovelFlattening(serverPlayer, hand, clickPos, data);
+		}
+
+		return didWork;
 	}
 }


### PR DESCRIPTION
I do have a mod called [Vanilla AIOTs](https://legacy.curseforge.com/minecraft/mc-mods/vanilla-aiots) and recently got a comment why the AIOTs aren't compatible with FTB Ultimine on right-clicks. Turns out, you checked for instances of certain tools. On Forge, there are `ToolAction`s for these things. Because of that, I just added them on the Forge side of things. On Fabric, I left it as it was since I don't know how Fabric manages things like this, if they even do. Maybe a proper way would be to check for the tags like `#minecraft:hoes`, but in case of AIOTs, they aren't even in this category. 

I wanted to create an issue for that, but I think that's easier to just create a pull request, so that you understand what I mean without me trying to explain it. Obviously, I could do the same PRs on 1.20.4, 1.20.6, and 1.21/dev, too. I just don't want to until I know if it's fine, and the user in my comment asked for compatibility in 1.20.1. 

---

Original PR: #158 (Re-created because I'm not very good at handling merge conflicts)