### PR TITLE
fix: return null instead of PASS in Fabric USE_ITEM_ON handler

### DIFF
--- a/fabric/src/main/java/dev/ftb/mods/ftbultimine/fabric/FTBUltimineFabric.java
+++ b/fabric/src/main/java/dev/ftb/mods/ftbultimine/fabric/FTBUltimineFabric.java
@@ -19,6 +19,7 @@ import net.fabricmc.fabric.api.event.lifecycle.v1.ServerTickEvents;
 import net.fabricmc.fabric.api.event.player.BlockEvents;
 import net.fabricmc.fabric.api.event.player.PlayerBlockBreakEvents;
 import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.InteractionResult;
 
 public class FTBUltimineFabric implements ModInitializer {
 	private FTBUltimine ultimine;
@@ -36,8 +37,10 @@ public class FTBUltimineFabric implements ModInitializer {
 		ServerTickEvents.END_SERVER_TICK.register(ultimine::serverTick);
 		PlayerBlockBreakEvents.BEFORE.register((level, player, blockPos, blockState, _) ->
 				!(player instanceof ServerPlayer sp) || !ultimine.handleBlockBreak(level, blockPos, blockState, sp));
-		BlockEvents.USE_ITEM_ON.register((_, _, _, blockPos, player, hand, _) ->
-				ultimine.blockRightClick(player, hand, blockPos));
+		BlockEvents.USE_ITEM_ON.register((_, _, _, blockPos, player, hand, _) -> {
+				InteractionResult result = ultimine.blockRightClick(player, hand, blockPos);
+				return result.consumesAction() ? result : null;
+			});
 		CommandRegistrationCallback.EVENT.register(FTBUltimineCommands::registerCommands);
 		// see PlayerMixin & PersistentEntitySectionManagerMixin for handling player tick & entity join "events"
 


### PR DESCRIPTION
## Summary
- `BlockEvents.USE_ITEM_ON` (introduced in Fabric 26.1) replaces vanilla block interaction for **any non-null return**, including `InteractionResult.PASS`
- This prevented opening containers (shulker boxes, chests, barrels, etc.) when FTB Ultimine was installed
- Fix: return `null` instead of `PASS` when the mod doesn't handle the interaction, allowing vanilla to process it normally

## Details
In `FTBUltimineFabric.java`, the `USE_ITEM_ON` callback now checks `result.consumesAction()`:
- `true` → return the result (ultimine handled it)
- `false` → return `null` (let vanilla handle it)

The NeoForge side is unaffected since its event system handles `PASS` correctly.

## Related issues
- Fixes FTBTeam/FTB-Mods-Issues#2030
- Fixes FTBTeam/FTB-Mods-Issues#2031
- Fixes FTBTeam/FTB-Mods-Issues#2032

## Test plan
- [x] Verified shulker boxes can be opened with FTB Ultimine installed
- [x] Verified ultimine right-click features (crop harvesting, axe stripping) still work
- [x] Build succeeds with `./gradlew :fabric:build`