### PR TITLE
feat: bulk-plant seeds on farmland with ultimine

### DIFF
--- a/common/src/main/java/dev/ftb/mods/ftbultimine/FTBUltimine.java
+++ b/common/src/main/java/dev/ftb/mods/ftbultimine/FTBUltimine.java
@@ -111,6 +111,7 @@ public class FTBUltimine {
 		event.registerHandler(AxeStripping.INSTANCE);
 		event.registerHandler(ShovelFlattening.INSTANCE);
 		event.registerHandler(FarmlandConversion.INSTANCE);
+		event.registerHandler(CropPlanting.INSTANCE);
 		event.registerHandler(CropHarvesting.INSTANCE);
 	}
 

--- a/common/src/main/java/dev/ftb/mods/ftbultimine/config/FTBUltimineServerConfig.java
+++ b/common/src/main/java/dev/ftb/mods/ftbultimine/config/FTBUltimineServerConfig.java
@@ -37,6 +37,8 @@ public interface FTBUltimineServerConfig {
 			.comment("Right-click with a shovel with the Ultimine key held to flatten multiple grass/dirt blocks into dirt paths");
 	BooleanValue RIGHT_CLICK_HOE = FEATURES.addBoolean("right_click_hoe", true)
 			.comment("Right-click with a hoe with the Ultimine key held to till multiple grass/dirt blocks into farmland");
+	BooleanValue RIGHT_CLICK_PLANTING = FEATURES.addBoolean("right_click_planting", true)
+			.comment("Right-click with seeds (wheat, carrots, potatoes, etc.) on farmland with the Ultimine key held to plant on multiple farmland blocks at once");
 	BooleanValue RIGHT_CLICK_HARVESTING = FEATURES.addBoolean("right_click_harvesting", true)
 			.comment("Right-click crops with the Ultimine key held to harvest multiple crop blocks");
 	BooleanValue RIGHT_CLICK_CRYSTALS = FEATURES.addBoolean("right_click_crystals", true)

--- a/common/src/main/java/dev/ftb/mods/ftbultimine/rightclick/CropPlanting.java
+++ b/common/src/main/java/dev/ftb/mods/ftbultimine/rightclick/CropPlanting.java
@@ -1,0 +1,64 @@
+package dev.ftb.mods.ftbultimine.rightclick;
+
+import dev.ftb.mods.ftbultimine.api.rightclick.RightClickHandler;
+import dev.ftb.mods.ftbultimine.api.shape.ShapeContext;
+import dev.ftb.mods.ftbultimine.config.FTBUltimineServerConfig;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
+import net.minecraft.resources.Identifier;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.tags.ItemTags;
+import net.minecraft.tags.TagKey;
+import net.minecraft.world.InteractionHand;
+import net.minecraft.world.item.BlockItem;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.context.UseOnContext;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.Blocks;
+import net.minecraft.world.level.block.CropBlock;
+import net.minecraft.world.level.block.StemBlock;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.phys.BlockHitResult;
+import net.minecraft.world.phys.Vec3;
+
+import java.util.Collection;
+
+public enum CropPlanting implements RightClickHandler {
+    INSTANCE;
+
+    private static final TagKey<Item> SEEDS_TAG = TagKey.create(net.minecraft.core.registries.Registries.ITEM, Identifier.parse("c:seeds"));
+
+    @Override
+    public int handleRightClickBlock(ShapeContext shapeContext, InteractionHand hand, Collection<BlockPos> positions) {
+        ServerPlayer player = shapeContext.player();
+        ItemStack stack = player.getItemInHand(hand);
+
+        if (!FTBUltimineServerConfig.RIGHT_CLICK_PLANTING.get() || !isPlantable(stack)) {
+            return 0;
+        }
+
+        Level level = player.level();
+        int planted = 0;
+        for (BlockPos pos : positions) {
+            if (level.getBlockState(pos).getBlock() != Blocks.FARMLAND) continue;
+            BlockPos above = pos.above();
+            if (!level.getBlockState(above).isAir()) continue;
+
+            BlockHitResult hitResult = new BlockHitResult(Vec3.atBottomCenterOf(above), Direction.UP, pos, false);
+            if (stack.useOn(new UseOnContext(player, hand, hitResult)).consumesAction()) {
+                planted++;
+                if (stack.isEmpty()) break;
+            }
+        }
+        return planted;
+    }
+
+    private static boolean isPlantable(ItemStack stack) {
+        if (stack.is(SEEDS_TAG)) return true;
+        if (stack.getItem() instanceof BlockItem blockItem) {
+            return blockItem.getBlock() instanceof CropBlock || blockItem.getBlock() instanceof StemBlock;
+        }
+        return false;
+    }
+}

--- a/common/src/main/resources/assets/ftbultimine/lang/en_us.json
+++ b/common/src/main/resources/assets/ftbultimine/lang/en_us.json
@@ -57,6 +57,8 @@
 	"ftbultimine.server_settings.features.right_click_axe": "Axe: Right-Click multiple blocks",
 	"ftbultimine.server_settings.features.right_click_hoe": "Hoe: Right-Click multiple blocks",
 	"ftbultimine.server_settings.features.right_click_shovel": "Shovel: Right-Click multiple blocks",
+	"ftbultimine.server_settings.features.right_click_planting": "Seeds: Plant on multiple farmland blocks",
+	"ftbultimine.server_settings.features.right_click_planting.tooltip": "Right-click with seeds (wheat, carrots, potatoes, etc.) on farmland while holding the Ultimine key to plant on multiple farmland blocks at once",
 	"ftbultimine.server_settings.features.right_click_harvesting": "Allow Ultimine harvesting of crops",
 	"ftbultimine.server_settings.features.right_click_crystals": "Allow Ultimine harvesting of crystals",
 	"ftbultimine.server_settings.features.right_click_crystals.tooltip": "Requires the FTB Ez Crystals mod to be installed (NeoForge only)\nHarvest vanilla Amethyst and other modded crystals",


### PR DESCRIPTION
## Motivation
In my forever "vanilla" world I build a very VERY big wheat field.
<img width="1920" height="1009" alt="2026-04-19_16 22 22" src="https://github.com/user-attachments/assets/83a080d3-6166-4317-9501-0eb53da57885" />
And I thought maybe I could write this feature for ultimine to plant multiple crops. I hope this fits into the mod :)

## Summary

Adds a new right-click handler that plants seeds on multiple connected farmland blocks at once when the Ultimine key is held — analogous to the existing shovel/hoe/axe bulk actions.

## How it works
- Player holds the Ultimine key, looks at a farmland block, and right-clicks with seeds in hand
- The shape system selects all connected farmland blocks
- For each farmland position with empty space above, the held item is `useOn`'d (vanilla planting logic)
- Stops automatically when the held stack runs out

## Seed detection
Two-tier check for maximum mod compatibility:
1. **`c:seeds` item tag** — covers most modded seeds (Croptopia, Farmer's Delight, etc.)
2. **`BlockItem` containing `CropBlock` or `StemBlock`** — covers all vanilla seeds (wheat, beetroot, carrots, potatoes, pumpkin/melon seeds) and any mod extending these vanilla classes

## Configuration
New server config option `right_click_planting` (default: `true`) — can be toggled in the in-game config GUI under "Features".

## Files changed
- `common/.../rightclick/CropPlanting.java` — new handler
- `common/.../FTBUltimine.java` — register handler in `registerBuiltinRightClickHandlers`
- `common/.../config/FTBUltimineServerConfig.java` — new `RIGHT_CLICK_PLANTING` config option
- `common/.../lang/en_us.json` — config GUI translations

## Notes
- Implementation lives in `common/`, so works for both Fabric and NeoForge automatically
- Returns the number of planted seeds so the existing XP/cooldown logic in `FTBUltimine#blockRightClick` works correctly
- Only targets `Blocks.FARMLAND` — saplings, sweet berry bushes etc. would need separate handling

## Test plan
- [x] Wheat seeds plant on multiple farmland blocks
- [x] Carrots, potatoes, beetroot seeds work
- [x] Pumpkin/melon seeds work
- [x] Stops when stack runs out
- [x] Skips already-planted farmland
- [x] Other right-click features (axe stripping, shovel flattening, hoe tilling, crop harvesting) still work
- [x] Build succeeds with `./gradlew :fabric:build`