### PR TITLE
feat: limit ultimine outline preview to plantable positions

### DIFF
--- a/common/src/main/java/dev/ftb/mods/ftbultimine/FTBUltimine.java
+++ b/common/src/main/java/dev/ftb/mods/ftbultimine/FTBUltimine.java
@@ -111,6 +111,7 @@ public class FTBUltimine {
 		event.registerHandler(AxeStripping.INSTANCE);
 		event.registerHandler(ShovelFlattening.INSTANCE);
 		event.registerHandler(FarmlandConversion.INSTANCE);
+		event.registerHandler(CropPlanting.INSTANCE);
 		event.registerHandler(CropHarvesting.INSTANCE);
 	}
 

--- a/common/src/main/java/dev/ftb/mods/ftbultimine/FTBUltiminePlayerData.java
+++ b/common/src/main/java/dev/ftb/mods/ftbultimine/FTBUltiminePlayerData.java
@@ -1,10 +1,12 @@
 package dev.ftb.mods.ftbultimine;
 
 import dev.ftb.mods.ftblibrary.platform.network.Server2PlayNetworking;
+import dev.ftb.mods.ftbultimine.api.rightclick.RightClickHandler;
 import dev.ftb.mods.ftbultimine.api.shape.Shape;
 import dev.ftb.mods.ftbultimine.api.shape.ShapeContext;
 import dev.ftb.mods.ftbultimine.config.FTBUltimineServerConfig;
 import dev.ftb.mods.ftbultimine.net.SendShapePacket;
+import dev.ftb.mods.ftbultimine.rightclick.RightClickDispatcher;
 import dev.ftb.mods.ftbultimine.shape.BlockMatchers;
 import dev.ftb.mods.ftbultimine.shape.ShapeRegistry;
 import net.minecraft.commands.CommandSourceStack;
@@ -154,6 +156,13 @@ public class FTBUltiminePlayerData {
 				int max = (int) (player.totalExperience / FTBUltimineServerConfig.getExperiencePerBlock(player));
 				if (max < cachedBlocks.size()) {
 					cachedBlocks = cachedBlocks.subList(0, max);
+				}
+			}
+			for (RightClickHandler handler : RightClickDispatcher.INSTANCE.getHandlers()) {
+				List<BlockPos> filtered = handler.filterPreview(player, cachedBlocks);
+				if (filtered != null) {
+					cachedBlocks = filtered;
+					break;
 				}
 			}
 		}

--- a/common/src/main/java/dev/ftb/mods/ftbultimine/api/rightclick/RightClickHandler.java
+++ b/common/src/main/java/dev/ftb/mods/ftbultimine/api/rightclick/RightClickHandler.java
@@ -7,8 +7,10 @@ import net.minecraft.world.InteractionHand;
 import net.minecraft.world.entity.EquipmentSlot;
 import net.minecraft.world.item.ItemStack;
 import org.jetbrains.annotations.ApiStatus;
+import org.jspecify.annotations.Nullable;
 
 import java.util.Collection;
+import java.util.List;
 
 /// Register implementations of this interface via the [RegisterRightClickHandlerEvent] event handler.
 public interface RightClickHandler {
@@ -21,6 +23,21 @@ public interface RightClickHandler {
     /// @param positions    the block positions covered by the current ultimining shape
     /// @return the number of blocks actually affected by this operation (return 0 if the operation is for any reason not applicable)
     int handleRightClickBlock(ShapeContext shapeContext, InteractionHand hand, Collection<BlockPos> positions);
+
+    /// Optional preview filter for the Ultimine block outline shown to the player. Called every tick while the
+    /// Ultimine key is held. Handlers can return a filtered (or reduced) subset of `positions` to restrict the
+    /// preview to only the blocks this handler would actually act on, given the player's currently held items
+    /// and world state.
+    ///
+    /// Implementations should return `null` if this handler does not apply (e.g. the held item isn't relevant).
+    /// The first handler to return a non-null result wins; subsequent handlers are not consulted for the preview.
+    ///
+    /// @param player    the player holding the Ultimine key
+    /// @param positions the current shape positions
+    /// @return a filtered list of positions, or `null` if this handler is not applicable
+    default @Nullable List<BlockPos> filterPreview(ServerPlayer player, List<BlockPos> positions) {
+        return null;
+    }
 
     /// Convenience method to damage a tool item on use. Can be called by right-click handlers when processing blocks.
     ///

--- a/common/src/main/java/dev/ftb/mods/ftbultimine/config/FTBUltimineServerConfig.java
+++ b/common/src/main/java/dev/ftb/mods/ftbultimine/config/FTBUltimineServerConfig.java
@@ -37,6 +37,8 @@ public interface FTBUltimineServerConfig {
 			.comment("Right-click with a shovel with the Ultimine key held to flatten multiple grass/dirt blocks into dirt paths");
 	BooleanValue RIGHT_CLICK_HOE = FEATURES.addBoolean("right_click_hoe", true)
 			.comment("Right-click with a hoe with the Ultimine key held to till multiple grass/dirt blocks into farmland");
+	BooleanValue RIGHT_CLICK_PLANTING = FEATURES.addBoolean("right_click_planting", true)
+			.comment("Right-click with seeds (wheat, carrots, potatoes, etc.) on farmland with the Ultimine key held to plant on multiple farmland blocks at once");
 	BooleanValue RIGHT_CLICK_HARVESTING = FEATURES.addBoolean("right_click_harvesting", true)
 			.comment("Right-click crops with the Ultimine key held to harvest multiple crop blocks");
 	BooleanValue RIGHT_CLICK_CRYSTALS = FEATURES.addBoolean("right_click_crystals", true)

--- a/common/src/main/java/dev/ftb/mods/ftbultimine/rightclick/CropPlanting.java
+++ b/common/src/main/java/dev/ftb/mods/ftbultimine/rightclick/CropPlanting.java
@@ -21,8 +21,11 @@ import net.minecraft.world.level.block.StemBlock;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.phys.BlockHitResult;
 import net.minecraft.world.phys.Vec3;
+import org.jspecify.annotations.Nullable;
 
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.List;
 
 public enum CropPlanting implements RightClickHandler {
     INSTANCE;
@@ -52,6 +55,28 @@ public enum CropPlanting implements RightClickHandler {
             }
         }
         return planted;
+    }
+
+    @Override
+    public @Nullable List<BlockPos> filterPreview(ServerPlayer player, List<BlockPos> positions) {
+        if (!FTBUltimineServerConfig.RIGHT_CLICK_PLANTING.get()) return null;
+
+        ItemStack stack = player.getMainHandItem();
+        if (!isPlantable(stack)) {
+            stack = player.getOffhandItem();
+            if (!isPlantable(stack)) return null;
+        }
+
+        int seedCount = stack.getCount();
+        Level level = player.level();
+        List<BlockPos> filtered = new ArrayList<>();
+        for (BlockPos pos : positions) {
+            if (filtered.size() >= seedCount) break;
+            if (level.getBlockState(pos).getBlock() != Blocks.FARMLAND) continue;
+            if (!level.getBlockState(pos.above()).isAir()) continue;
+            filtered.add(pos);
+        }
+        return filtered;
     }
 
     private static boolean isPlantable(ItemStack stack) {

--- a/common/src/main/java/dev/ftb/mods/ftbultimine/rightclick/CropPlanting.java
+++ b/common/src/main/java/dev/ftb/mods/ftbultimine/rightclick/CropPlanting.java
@@ -1,0 +1,64 @@
+package dev.ftb.mods.ftbultimine.rightclick;
+
+import dev.ftb.mods.ftbultimine.api.rightclick.RightClickHandler;
+import dev.ftb.mods.ftbultimine.api.shape.ShapeContext;
+import dev.ftb.mods.ftbultimine.config.FTBUltimineServerConfig;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
+import net.minecraft.resources.Identifier;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.tags.ItemTags;
+import net.minecraft.tags.TagKey;
+import net.minecraft.world.InteractionHand;
+import net.minecraft.world.item.BlockItem;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.context.UseOnContext;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.Blocks;
+import net.minecraft.world.level.block.CropBlock;
+import net.minecraft.world.level.block.StemBlock;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.phys.BlockHitResult;
+import net.minecraft.world.phys.Vec3;
+
+import java.util.Collection;
+
+public enum CropPlanting implements RightClickHandler {
+    INSTANCE;
+
+    private static final TagKey<Item> SEEDS_TAG = TagKey.create(net.minecraft.core.registries.Registries.ITEM, Identifier.parse("c:seeds"));
+
+    @Override
+    public int handleRightClickBlock(ShapeContext shapeContext, InteractionHand hand, Collection<BlockPos> positions) {
+        ServerPlayer player = shapeContext.player();
+        ItemStack stack = player.getItemInHand(hand);
+
+        if (!FTBUltimineServerConfig.RIGHT_CLICK_PLANTING.get() || !isPlantable(stack)) {
+            return 0;
+        }
+
+        Level level = player.level();
+        int planted = 0;
+        for (BlockPos pos : positions) {
+            if (level.getBlockState(pos).getBlock() != Blocks.FARMLAND) continue;
+            BlockPos above = pos.above();
+            if (!level.getBlockState(above).isAir()) continue;
+
+            BlockHitResult hitResult = new BlockHitResult(Vec3.atBottomCenterOf(above), Direction.UP, pos, false);
+            if (stack.useOn(new UseOnContext(player, hand, hitResult)).consumesAction()) {
+                planted++;
+                if (stack.isEmpty()) break;
+            }
+        }
+        return planted;
+    }
+
+    private static boolean isPlantable(ItemStack stack) {
+        if (stack.is(SEEDS_TAG)) return true;
+        if (stack.getItem() instanceof BlockItem blockItem) {
+            return blockItem.getBlock() instanceof CropBlock || blockItem.getBlock() instanceof StemBlock;
+        }
+        return false;
+    }
+}

--- a/common/src/main/java/dev/ftb/mods/ftbultimine/rightclick/RightClickDispatcher.java
+++ b/common/src/main/java/dev/ftb/mods/ftbultimine/rightclick/RightClickDispatcher.java
@@ -32,6 +32,10 @@ public enum RightClickDispatcher {
         handlers.add(handler);
     }
 
+    public List<RightClickHandler> getHandlers() {
+        return handlers;
+    }
+
     public void clear() {
         handlers.clear();
     }

--- a/common/src/main/resources/assets/ftbultimine/lang/en_us.json
+++ b/common/src/main/resources/assets/ftbultimine/lang/en_us.json
@@ -57,6 +57,8 @@
 	"ftbultimine.server_settings.features.right_click_axe": "Axe: Right-Click multiple blocks",
 	"ftbultimine.server_settings.features.right_click_hoe": "Hoe: Right-Click multiple blocks",
 	"ftbultimine.server_settings.features.right_click_shovel": "Shovel: Right-Click multiple blocks",
+	"ftbultimine.server_settings.features.right_click_planting": "Seeds: Plant on multiple farmland blocks",
+	"ftbultimine.server_settings.features.right_click_planting.tooltip": "Right-click with seeds (wheat, carrots, potatoes, etc.) on farmland while holding the Ultimine key to plant on multiple farmland blocks at once",
 	"ftbultimine.server_settings.features.right_click_harvesting": "Allow Ultimine harvesting of crops",
 	"ftbultimine.server_settings.features.right_click_crystals": "Allow Ultimine harvesting of crystals",
 	"ftbultimine.server_settings.features.right_click_crystals.tooltip": "Requires the FTB Ez Crystals mod to be installed (NeoForge only)\nHarvest vanilla Amethyst and other modded crystals",


### PR DESCRIPTION
> ⚠️ **Depends on #182** — that PR introduces the bulk-planting feature this PR builds on. Please review/merge #182 first. Once it's merged, this PR will only show the preview filter changes.

## Motivation
The bulk-planting feature in #182 lets players plant seeds across a whole shape selection at once. But the existing Ultimine outline preview always shows the full shape, even when the player only has 4 seeds in hand and the selected shape covers 9 farmland blocks. This is misleading — the player sees 9 outlines but only 4 will actually get planted.

This PR makes the preview honest: it shows exactly the blocks that will be acted on, given the player's current inventory and the world state.

## Summary
- New optional `filterPreview` default method on the `RightClickHandler` API
- Handlers can return a filtered subset of the current shape positions to restrict the visible outline preview
- `CropPlanting` implements this to limit the preview to:
  - Farmland blocks with empty space above
  - A maximum count equal to the number of seeds in the player's hand (main or off-hand)

## Result
Holding 4 wheat seeds + Small Square (3x3) shape on farmland → preview shows exactly 4 outlines instead of 9. Same for any seed count and shape.

## API design
The new method has a default `null` return, so existing handlers remain fully compatible — they simply opt out of preview filtering. The first handler to return a non-null result wins; subsequent handlers are skipped. This mirrors the dispatcher's existing first-non-zero-wins pattern for click handling.

This also opens the door for other handlers (e.g. axe stripping, hoe tilling) to add similar previews in future, e.g. respecting tool durability.

## Files changed
- `common/.../api/rightclick/RightClickHandler.java` — new `filterPreview` default method
- `common/.../rightclick/RightClickDispatcher.java` — public `getHandlers()` accessor
- `common/.../rightclick/CropPlanting.java` — `filterPreview` implementation
- `common/.../FTBUltiminePlayerData.java` — calls `filterPreview` on registered handlers in `updateBlocks`

## Test plan
- [x] 4 wheat seeds + 3x3 square on farmland → 4 outlines shown
- [x] Full stack of 64 seeds + 3x3 square → 9 outlines shown (full shape)
- [x] Stack with mixed planted/empty farmland → only empty positions shown
- [x] Other right-click features (axe, hoe, shovel) preview unchanged
- [x] Build succeeds with `./gradlew :fabric:build`